### PR TITLE
Allow admins to edit roles

### DIFF
--- a/backend/app/auth/exceptions.py
+++ b/backend/app/auth/exceptions.py
@@ -19,3 +19,7 @@ USERNAME_TAKEN_EXCEPTION = HTTPException(
 AUTHENTICATION_2FA_EXCEPTION = HTTPException(
     status_code=status.HTTP_302_FOUND, detail="User found. 2FA authentication required."
 )
+
+NO_PERMISSION_EXCEPTION = HTTPException(
+    status_code=status.HTTP_403_FORBIDDEN, detail="You don't have enough permissions."
+)

--- a/backend/app/auth/schemas.py
+++ b/backend/app/auth/schemas.py
@@ -29,3 +29,16 @@ class UserMetadata(BaseModel):
     files_quota: int
     size_quota: int
     is_2fa_enabled: bool
+
+
+class RoleMetadata(BaseModel):
+    id: str
+    name: str
+    quota_size: int
+    quota_files: int
+
+
+class UpdateRole(BaseModel):
+    role_id: str
+    size: int
+    files: int

--- a/frontend/src/lib/components/admin/RoleRow.svelte
+++ b/frontend/src/lib/components/admin/RoleRow.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import type { RoleMetadata } from '$lib/types/RoleMetadata';
+  import {
+    ActionIcon,
+    Box,
+    Button,
+    Flex,
+    NumberInput,
+    Overlay,
+    Text,
+    Title,
+    Tooltip,
+    createStyles,
+    type theme
+  } from '@svelteuidev/core';
+  import { isAxiosError } from 'axios';
+  import { Update } from 'radix-icons-svelte';
+  import { editRole } from '../../../server/auth';
+
+  export let role: RoleMetadata;
+  let filesQuota: number = role.quota_files;
+  let spaceQuota: number = role.quota_size;
+
+  const useStyles = createStyles((theme: theme) => {
+    return {
+      root: {
+        [`${theme.dark} &`]: {
+          bc: theme.fn.themeColor('dark', 5),
+          color: 'white'
+        },
+        backgroundColor: '$gray50',
+        textAlign: 'center',
+        padding: '$10',
+        borderRadius: '$md',
+        marginTop: '$3',
+        marginBottom: '$3'
+      },
+      flexOverlay: {
+        display: 'flex',
+        height: '100%',
+        justifyContent: 'center',
+        alignItems: 'center',
+        direction: 'column',
+        backdropFilter: 'blur(5px)'
+      }
+    };
+  });
+
+  const saveRole = async () => {
+    const accessToken = localStorage.getItem('accessToken');
+
+    if (!accessToken) {
+      window.location.href = '/auth/login';
+      return;
+    }
+
+    try {
+      await editRole(accessToken, role.id, spaceQuota, filesQuota);
+      location.reload();
+    } catch (error) {
+      if (!isAxiosError(error)) {
+        alert('An unknown error occurred.');
+        return;
+      }
+
+      if (error.response?.status === 403) {
+        alert('You do not have permission to edit this role.');
+        return;
+      }
+
+      alert('An error occurred while editing the role.');
+    }
+  };
+
+  let overlayShown = false;
+
+  $: ({ classes, getStyles } = useStyles());
+</script>
+
+<Box class={getStyles()}>
+  <Flex align="center" justify="space-evenly" style="height: 100%;">
+    <Text size="sm" css={{ flex: 1, textAlign: 'center' }}>
+      {role.name.toUpperCase()}
+    </Text>
+    <Text size="sm" css={{ flex: 1, textAlign: 'center' }}>
+      {role.quota_files}
+    </Text>
+    <Text size="sm" css={{ flex: 1, textAlign: 'center' }}>
+      {role.quota_size}
+    </Text>
+    <Flex justify="center" gap="xs" css={{ flex: 1 }}>
+      <Tooltip openDelay={10} label="Edit">
+        <ActionIcon variant="filled" color="blue" on:click={() => (overlayShown = true)}>
+          <Update size={20} />
+        </ActionIcon>
+      </Tooltip>
+    </Flex>
+  </Flex>
+</Box>
+
+{#if overlayShown}
+  <Overlay opacity={1} color="#000" zIndex={5} center class={classes.flexOverlay}>
+    <Box class={getStyles()}>
+      <Flex direction="column" align="space-evenly" gap="l" justify="center">
+        <Title order={3}>Edit Role</Title>
+        <NumberInput
+          bind:value={filesQuota}
+          placeholder="Files..."
+          label="Files Quota"
+          invalid={filesQuota < 0}
+          hideControls
+          required
+        />
+        <NumberInput
+          bind:value={spaceQuota}
+          placeholder="Space..."
+          label="Space Quota"
+          invalid={spaceQuota < 0}
+          hideControls
+          required
+        />
+        <Flex gap="lg" justify="space-between">
+          <Button variant="filled" on:click={saveRole}>Submit</Button>
+          <Button variant="light" on:click={() => (overlayShown = false)}>Close</Button>
+        </Flex>
+      </Flex>
+    </Box>
+  </Overlay>
+{/if}

--- a/frontend/src/lib/components/admin/TitleRoleRow.svelte
+++ b/frontend/src/lib/components/admin/TitleRoleRow.svelte
@@ -11,7 +11,7 @@
         backgroundColor: '$gray20',
         textAlign: 'center',
         padding: '$10',
-        borderRadius: '$md',
+        borderRadius: '$md'
       },
       textStyle: {
         flex: 1,

--- a/frontend/src/lib/components/admin/TitleRoleRow.svelte
+++ b/frontend/src/lib/components/admin/TitleRoleRow.svelte
@@ -26,7 +26,8 @@
 <Box class={getStyles()}>
   <Flex align="center" justify="space-evenly" style="height: 100%;">
     <Text size="md" weight="bold" transform="uppercase" class={classes.textStyle}>Name</Text>
-    <Text size="md" weight="bold" transform="uppercase" class={classes.textStyle}>URL</Text>
+    <Text size="md" weight="bold" transform="uppercase" class={classes.textStyle}>Files Quota</Text>
+    <Text size="md" weight="bold" transform="uppercase" class={classes.textStyle}>Space Quota</Text>
     <Text size="md" weight="bold" transform="uppercase" class={classes.textStyle}>Actions</Text>
   </Flex>
 </Box>

--- a/frontend/src/lib/components/user/FileRow.svelte
+++ b/frontend/src/lib/components/user/FileRow.svelte
@@ -49,7 +49,9 @@
         backgroundColor: '$gray50',
         textAlign: 'center',
         padding: '$10',
-        borderRadius: '$md'
+        borderRadius: '$md',
+        marginTop: '$3',
+        marginBottom: '$3'
       },
       flexOverlay: {
         display: 'flex',
@@ -359,7 +361,7 @@
 {/if}
 
 {#if isDownloadWindowVisible}
-  <Overlay opacity={0.9} color="#000" zIndex={5} center class={classes.flexOverlay}>
+  <Overlay opacity={1} color="#000" zIndex={5} center class={classes.flexOverlay}>
     <Box class={getStyles()}>
       <Flex direction="column" align="space-evenly" gap="l" justify="center">
         <Title order={3}>Download File</Title>

--- a/frontend/src/lib/components/user/TitleFileRow.svelte
+++ b/frontend/src/lib/components/user/TitleFileRow.svelte
@@ -12,9 +12,6 @@
         textAlign: 'center',
         padding: '$10',
         borderRadius: '$md',
-        '&:hover': {
-          backgroundColor: '$gray50'
-        }
       },
       textStyle: {
         flex: 1,

--- a/frontend/src/lib/components/user/TitleFileRow.svelte
+++ b/frontend/src/lib/components/user/TitleFileRow.svelte
@@ -11,7 +11,7 @@
         backgroundColor: '$gray20',
         textAlign: 'center',
         padding: '$10',
-        borderRadius: '$md',
+        borderRadius: '$md'
       },
       textStyle: {
         flex: 1,

--- a/frontend/src/lib/components/user/TitleWebhookRow.svelte
+++ b/frontend/src/lib/components/user/TitleWebhookRow.svelte
@@ -11,7 +11,7 @@
         backgroundColor: '$gray20',
         textAlign: 'center',
         padding: '$10',
-        borderRadius: '$md',
+        borderRadius: '$md'
       },
       textStyle: {
         flex: 1,

--- a/frontend/src/lib/components/user/WebhookRow.svelte
+++ b/frontend/src/lib/components/user/WebhookRow.svelte
@@ -25,9 +25,6 @@
         textAlign: 'center',
         padding: '$10',
         borderRadius: '$md',
-        '&:hover': {
-          backgroundColor: '$gray100'
-        }
       }
     };
   });

--- a/frontend/src/lib/components/user/WebhookRow.svelte
+++ b/frontend/src/lib/components/user/WebhookRow.svelte
@@ -24,7 +24,7 @@
         backgroundColor: '$gray50',
         textAlign: 'center',
         padding: '$10',
-        borderRadius: '$md',
+        borderRadius: '$md'
       }
     };
   });

--- a/frontend/src/lib/types/RoleMetadata.ts
+++ b/frontend/src/lib/types/RoleMetadata.ts
@@ -1,0 +1,6 @@
+export type RoleMetadata = {
+  id: string;
+  name: string;
+  quota_size: number;
+  quota_files: number;
+};

--- a/frontend/src/routes/admin/roles/+page.svelte
+++ b/frontend/src/routes/admin/roles/+page.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import RoleRow from '$lib/components/admin/RoleRow.svelte';
+  import TitleRoleRow from '$lib/components/admin/TitleRoleRow.svelte';
+  import type { RoleMetadata } from '$lib/types/RoleMetadata';
+  import { Title } from '@svelteuidev/core';
+  import { onMount } from 'svelte';
+  import { getRoles } from '../../../server/auth';
+
+  let roles: RoleMetadata[] = [];
+
+  onMount(async () => {
+    const accessToken = localStorage.getItem('accessToken');
+
+    if (!accessToken) {
+      window.location.href = '/auth/login';
+      return;
+    }
+
+    roles = await getRoles(accessToken);
+  });
+</script>
+
+<div
+  style="display: flex; flex-direction: column; justify-content: center; align-items: center; margin-bottom: 2rem;"
+>
+  <Title order={1}>Roles</Title>
+</div>
+
+<TitleRoleRow />
+{#each roles as role}
+  <RoleRow {role} />
+{/each}

--- a/frontend/src/routes/user/account/+page.svelte
+++ b/frontend/src/routes/user/account/+page.svelte
@@ -106,4 +106,11 @@
   <Text
     >{storageUsed} / {user?.size_quota ?? 0} B ({((storageUsed ?? 0) / 1000 / 1000).toFixed(2)} MB)
   </Text>
+
+  {#if user?.role === 'admin'}
+    <br />
+    <Title>Admin</Title>
+
+    <Anchor href="/admin/roles">Manage Roles</Anchor>
+  {/if}
 </Flex>

--- a/frontend/src/routes/user/webhooks/+page.svelte
+++ b/frontend/src/routes/user/webhooks/+page.svelte
@@ -44,7 +44,9 @@
         backgroundColor: theme.fn.themeColor('gray', 1),
         opacity: 1,
         padding: 20,
-        borderRadius: '$md'
+        borderRadius: '$md',
+        marginTop: '$3',
+        marginBottom: '$3'
       },
       flexOverlay: {
         display: 'flex',

--- a/frontend/src/server/auth.ts
+++ b/frontend/src/server/auth.ts
@@ -1,5 +1,6 @@
 import type { AccessToken } from '$lib/types/AccessToken';
 import type { Code2FA } from '$lib/types/Code2FA';
+import type { RoleMetadata } from '$lib/types/RoleMetadata';
 import type { UserMetadata } from '$lib/types/UserMetadata';
 import axios from 'axios';
 
@@ -66,4 +67,37 @@ export const getUserMetadata = async (token: string) => {
   });
 
   return result;
+};
+
+export const getRoles = async (token: string) => {
+  const result = await axios.get<RoleMetadata[]>(`${BASE_URL}/auth/roles`, {
+    headers: {
+      authorization: `Bearer ${token}`
+    }
+  });
+
+  return result.data;
+};
+
+export const editRole = async (
+  token: string,
+  roleId: string,
+  sizeQuota: number,
+  filesQuota: number
+) => {
+  const result = await axios.post(
+    `${BASE_URL}/auth/roles/edit`,
+    {
+      role_id: roleId,
+      size: sizeQuota,
+      files: filesQuota
+    },
+    {
+      headers: {
+        authorization: `Bearer ${token}`
+      }
+    }
+  );
+
+  return result.data;
 };


### PR DESCRIPTION
- Allow admins to edit role quotas
- Protect new endpoints (on backend and on frontend), only for admins
- Add some new needed schemas and types for data transfering
- Add some margins to the tables, and remove the hover flicker
- Add admin section to the account route